### PR TITLE
Allow a fixed list of change addresses

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -323,6 +323,7 @@ std::string HelpMessage()
         "  -maxconnections=<n>    " + _("Maintain at most <n> connections to peers (default: 125)") + "\n" +
         "  -addnode=<ip>          " + _("Add a node to connect to and attempt to keep the connection open") + "\n" +
         "  -connect=<ip>          " + _("Connect only to the specified node(s)") + "\n" +
+        "  -change=<address>      " + _("Send change only to the specified address(es)") + "\n" +
         "  -seednode=<ip>         " + _("Connect to a node to retrieve peer addresses, and disconnect") + "\n" +
         "  -externalip=<ip>       " + _("Specify your own public address") + "\n" +
         "  -onlynet=<net>         " + _("Only connect to nodes in network <net> (IPv4, IPv6 or Tor)") + "\n" +

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1246,7 +1246,21 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64> >& vecSend,
                     // coin control: send change to custom address
                     if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange))
                         scriptChange.SetDestination(coinControl->destChange);
-                        
+                    
+                    // send change to one of the specified change addresses
+                    else if (mapArgs.count("-change") && mapMultiArgs["-change"].size() > 0)
+                    {
+                        CBitcoinAddress address(mapMultiArgs["-change"][GetRandInt(mapMultiArgs["-change"].size())]);
+
+                        CKeyID keyID;
+                        if (!address.GetKeyID(keyID)) {
+                            strFailReason = _("Bad change address");
+                            return false;
+                        }
+
+                        scriptChange.SetDestination(keyID);
+                    }
+                    
                     // no coin control: send change to newly generated address
                     else
                     {


### PR DESCRIPTION
All credit goes to @dooglus for making this change on Dogecoin. This is just something I would like to see in the Vertcoin client as well.

Almost a direct copy of his initial Pull https://github.com/dogecoin/dogecoin/pull/187

Almost every transaction out of a Vertcoin wallet makes a new change address in the wallet for 'change'. After a while a heavily used wallet gets very big and starts consuming all available CPU as it scans incoming transactions against an every-growing list of change addresses.

This pull request allows the user to specify a finite number of change addresses in vertcoin.conf and have transactions out of the wallet send change to one of the specified addresses at random.

In vertcoin.conf, specify 1 or more addresses, like this:

```
 change=Vaddress1
 change=Vaddress2
 [etc.]
```

If no change addresses are specified, vertcoin-qt will fall back to the previous behavior of making new change addresses per transaction.

This helps pools and coin services isolate all their change into one address which allows a a user to backup a set of private keys and not worry about loosing coins with change transactions
