### PR TITLE
Use secp256k1_ec_ prefix for non-ECDSA key operations

### DIFF
--- a/src/stealth.cpp
+++ b/src/stealth.cpp
@@ -123,7 +123,7 @@ ec_secret generate_random_secret()
 bool ec_multiply(ec_point& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_pubkey_tweak_mul(a.data(), a.size(), b.data());
+    return secp256k1_ec_pubkey_tweak_mul(a.data(), a.size(), b.data());
 }
 
 hash_digest sha256_hash(const data_chunk& chunk)
@@ -146,7 +146,7 @@ ec_secret shared_secret(const ec_secret& secret, ec_point point)
 bool ec_tweak_add(ec_point& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_pubkey_tweak_add(a.data(), a.size(), b.data());
+    return secp256k1_ec_pubkey_tweak_add(a.data(), a.size(), b.data());
 }
 
 ec_point secret_to_public_key(const ec_secret& secret,
@@ -159,7 +159,7 @@ ec_point secret_to_public_key(const ec_secret& secret,
 
     ec_point out(size);
     int out_size;
-    if (!secp256k1_ecdsa_pubkey_create(out.data(), &out_size, secret.data(),
+    if (!secp256k1_ec_pubkey_create(out.data(), &out_size, secret.data(),
             compressed))
         return ec_point();
     assert(size == static_cast<size_t>(out_size));
@@ -277,7 +277,7 @@ ec_point uncover_stealth(
 bool ec_add(ec_secret& a, const ec_secret& b)
 {
     init.init();
-    return secp256k1_ecdsa_privkey_tweak_add(a.data(), b.data());
+    return secp256k1_ec_privkey_tweak_add(a.data(), b.data());
 }
 
 ec_secret uncover_stealth_secret(


### PR DESCRIPTION
See API change @ https://github.com/bitcoin/secp256k1/commit/ae6bc76e32016063a591399a7a2d7bac646603bc
