### PR TITLE
Fixed a bug in the size of transaction fee.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ http://www.vertcoin.org
 
 Copyright (c) 2009-2013 Bitcoin Developers
 Copyright (c) 2011-2013 Litecoin Developers
-Copyright (c) 2014 Vertcoin Developers
+Copyright (c) 2014-2015 Vertcoin Developers
 
 What is Vertcoin?
 ----------------
@@ -46,6 +46,21 @@ controversial.
 The `master` branch is regularly built and tested, but is not guaranteed to be
 completely stable. [Tags](https://github.com/vertcoin/vertcoin/tags) are created
 regularly to indicate new official, stable release versions of Vertcoin.
+
+Building
+--------
+
+Environment specific building instructions are located in the following directories and files:
+
+vertcoind (headless wallet):
+
+* doc/build-msw.md (Windows)
+* doc/build-osx.md (Mac OS X)
+* doc/build-unix.md (Unix)
+
+vertcoin-qt (wallet with GUI):
+
+* doc/readme-qt.rst
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Vertcoin is a lite version of Bitcoin using Lyra2RE as a proof-of-work algorithm
  - 50 coins per block
  - Every block to retarget difficulty with Kimotos Gravity Well algorithm
 
+Vertcoin is also the first cryptocurrency to implement Stealth Addresses, a new technology for providing privacy on the public ledger.
+
 For more information, as well as an immediately useable, binary version of
 the Vertcoin client sofware, see http://www.vertcoin.org.
 

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -1,4 +1,5 @@
-Copyright (c) 2009-2013 Bitcoin Developers
+Copyright (c) 2009-2013 Bitcoin Developers (c) 2014-2015 Vertcoin Developers
+
 Distributed under the MIT/X11 software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.
 This product includes software developed by the OpenSSL Project for use in the [OpenSSL Toolkit](http://www.openssl.org/). This product includes

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2013 Bitcoin Developers
+Copyright (c) 2009-2013 Bitcoin Developers (c) 2014-2015 Vertcoin Developers
 
 Distributed under the MIT/X11 software license, see the accompanying
 file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -120,7 +120,7 @@ To compile Vertcoin with GNU make:
 
 Notes
 -----
-The release is built with GCC and then "strip bitcoind" to strip the debug
+The release is built with GCC and then "strip vertcoind" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
@@ -178,7 +178,7 @@ exploit even if a vulnerability is found, you can take the following measures:
 
 * Non-executable Stack
     If the stack is executable then trivial stack based buffer overflow exploits are possible if
-    vulnerable buffers are found. By default, bitcoin should be built with a non-executable stack
+    vulnerable buffers are found. By default, vertcoin should be built with a non-executable stack
     but if one of the libraries it uses asks for an executable stack or someone makes a mistake
     and uses a compiler extension which requires an executable stack, it will silently build an
     executable without the non-executable stack protection.

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1405,12 +1405,12 @@ bool CWallet::CreateTransaction(const vector<pair<pair<pair<CScript, int64>, ec_
                 dPriority /= nBytes;
 
                 // Check that enough fee is included
-                int64 nPayFee = nTransactionFee * (1 + (int64)nBytes / 1000);
-                bool fAllowFree = CTransaction::AllowFree(dPriority); 
+                bool fAllowFree = CTransaction::AllowFree(dPriority);
                 int64 nMinFee = wtxNew.GetMinFee(1, fAllowFree, GMF_SEND);
-                if (nFeeRet < max(nPayFee, nMinFee))
+
+                if (nFeeRet < nMinFee)
                 {
-                    nFeeRet = max(nPayFee, nMinFee);
+                    nFeeRet = nMinFee;
                     continue;
                 }
 


### PR DESCRIPTION
The transaction fee got always multiplied even if it was large enough.  I noticed this bug while moving Vertcoins around. The transaction fee was set to 1 VTC. Instead of accepting the already generous fee, the wallet was asking 3 VTC (!) for a transaction, haha. This commit should remove the possibility of paying too much. Check before pulling. I hope I didn't miss anything important. I haven't tested this fix on an actual transaction with a large fee.
